### PR TITLE
Fix tagList layout

### DIFF
--- a/src/components/PostListing/PostListing.scss
+++ b/src/components/PostListing/PostListing.scss
@@ -1,6 +1,11 @@
 .tagList-area {
-  margin-top: 12px;
-  margin-bottom: 12px;
-  width: 90%;
-  background-color: #ffffff;
+  width: 100%;
+  margin: auto;
+  padding: 0 !important;
+
+  @media (min-width: 840px - 1px) {
+    margin-top: 12px;
+    margin-bottom: 12px;
+    width: 90%;
+  }
 }


### PR DESCRIPTION
【修正】タグ一覧のモバイル対応 #23 のプルリク
839px(タブレットの横幅)で右端に表示されていた一覧を記事一覧の下に表示するように修正