### PR TITLE
Fix postDetail layout

### DIFF
--- a/src/components/PostSuggestions/PostSuggestions.scss
+++ b/src/components/PostSuggestions/PostSuggestions.scss
@@ -26,6 +26,15 @@
     .arrow-nav {
       margin-top: 15px;
     }
+
+    h6 {
+      @media (max-width: 840px - 1px) {
+        text-indent: -9999px;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+    }
+
   }
 
   .secondary-color {

--- a/src/templates/post.scss
+++ b/src/templates/post.scss
@@ -39,6 +39,11 @@ $phone-status-bar-height: 24px - 12px;
         max-width: 100%;
         word-wrap: break-word;
         white-space: normal;
+
+        @media (max-width: 840px - 1px) {
+            font-weight: bold;
+            font-size: 18px;
+        }
     }
 
     .post {


### PR DESCRIPTION
【修正】記事詳細画面のタイトルを画面サイズによって変更 #25 のプルリク

記事詳細画面のタイトルをモバイル端末で確認した際に、少し大きいので、
スマホ、タブレットの画面サイズの場合はサイズを少し下げる
スマホ、タブレットの画面サイズの場合は次の記事リンクボタンはタイトルを非表示にする